### PR TITLE
fix(index.*): fix import paths for case-sensitive OSes

### DIFF
--- a/template/src/index.js
+++ b/template/src/index.js
@@ -1,4 +1,4 @@
-import './Index.bs';
+import './index.bs';
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))

--- a/template/src/index.res
+++ b/template/src/index.res
@@ -1,4 +1,4 @@
-%%raw("import './Index.css'")
+%%raw("import './index.css'")
 
 ReactDOM.render(
   <React.StrictMode> <App /> </React.StrictMode>,


### PR DESCRIPTION
Current import paths work in Mac but not in Linux.